### PR TITLE
Ruby version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-.bundle
-.DS_Store
-.rvmrc
-.ruby-version
-.rbenv-gemsets
-.yardoc
-doc
 *.gem
 *.rbc
+.bundle
+.DS_Store
+.rbenv-gemsets
+.ruby-gemset
+.ruby-version
+.rvmrc
+.yardoc
+doc

--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,1 +1,0 @@
-heartcheck


### PR DESCRIPTION
If you want to use a specific gemset or ruby version you can do it in your machine but don’t add it to repo to force all developers to do the same.

Add ruby 2.2.2 as a supported ruby version.