### PR TITLE
[WIP] Intruduce: executors strategy and add elapsed time

### DIFF
--- a/lib/heartcheck.rb
+++ b/lib/heartcheck.rb
@@ -2,6 +2,7 @@ module Heartcheck
   require 'logger'
   require 'heartcheck/app'
   require 'heartcheck/checks'
+  require 'heartcheck/executors'
   require 'heartcheck/errors'
   require 'heartcheck/services'
   require 'heartcheck/logger'

--- a/lib/heartcheck/checks/base.rb
+++ b/lib/heartcheck/checks/base.rb
@@ -114,11 +114,9 @@ module Heartcheck
       # @return [Hash]
       def check
         validation
-        hash = { name => { 'status' => (@errors.empty? ? 'ok' : 'error') } }
-        hash[name]['message'] = error_message unless @errors.empty?
-
-        Logger.info Oj.dump(hash)
-        hash
+        { name => { 'status' => (@errors.empty? ? 'ok' : 'error') } }.tap do |response|
+          response[name]['message'] = error_message unless @errors.empty?
+        end
       end
 
       def informations

--- a/lib/heartcheck/controllers/base.rb
+++ b/lib/heartcheck/controllers/base.rb
@@ -13,9 +13,13 @@ module Heartcheck
       protected
 
       def check(who)
-        Oj.dump(Heartcheck
-                .send("#{who}_checks")
-                .map(&:check))
+        Oj.dump(executor.dispatch(Heartcheck.send("#{who}_checks")))
+      end
+
+      private
+
+      def executor
+        Heartcheck::Executors::Base.new
       end
     end
   end

--- a/lib/heartcheck/executors.rb
+++ b/lib/heartcheck/executors.rb
@@ -1,0 +1,1 @@
+require 'heartcheck/executors/base'

--- a/lib/heartcheck/executors/base.rb
+++ b/lib/heartcheck/executors/base.rb
@@ -1,0 +1,15 @@
+module Heartcheck
+  module Executors
+    class Base
+      def dispatch(checkers)
+        checkers.map do |checker|
+          started = Time.now
+          checker.check.tap do |checked|
+            checked[:time] = ((Time.now - started) * 1_000.0)
+            Logger.info Oj.dump(checked)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/heart-check/controllers/essential_spec.rb
+++ b/spec/lib/heart-check/controllers/essential_spec.rb
@@ -6,10 +6,16 @@ module Heartcheck
       describe '#index' do
         subject(:index) { controller.index }
 
-        let(:check_01) { { dummy1: { status: :ok } } }
-        let(:check_02) { { dummy2: { status: :ok } } }
+        let(:check_01) { { dummy1: { status: :ok }, time: 1100 } }
+        let(:check_02) { { dummy2: { status: :ok }, time: 100 } }
 
         before do
+          expect(Time).to receive(:now).and_return(
+                            # millisec time calc :p
+                            0.1, 1.2, # (1.2 - 0.1) * 1000.0 = 1100
+                            2.9, 3.0  # (3.0 - 2.9) * 1000.0 = 100
+                          )
+
           Heartcheck.setup do |monitor|
             monitor.add :dummy1 do |c|
               c.add_service(name: 'dummy1')

--- a/spec/lib/heart-check/controllers/functional_spec.rb
+++ b/spec/lib/heart-check/controllers/functional_spec.rb
@@ -6,15 +6,22 @@ module Heartcheck
       describe '#index' do
         subject(:index) { controller.index }
 
-        let(:check_01) { { dummy1: { status: :ok } } }
-        let(:check_02) { { dummy2: { status: :ok } } }
+        let(:check_01) { { dummy1: { status: :ok } , time: 1100 } }
+        let(:check_02) { { dummy2: { status: :ok } , time: 100 } }
 
         before do
+          expect(Time).to receive(:now).and_return(
+                            # millisec time calc :p
+                            0.1, 1.2, # (1.2 - 0.1) * 1000.0 = 1100
+                            2.9, 3.0  # (3.0 - 2.9) * 1000.0 = 100
+                          )
+
           Heartcheck.setup do |monitor|
             monitor.add :dummy1 do |c|
               c.add_service(name: 'dummy1')
               c.functional = true
             end
+
             monitor.add :dummy2 do |c|
               c.add_service(name: 'dummy2')
               c.functional = true

--- a/spec/lib/heart-check/executors/base_spec.rb
+++ b/spec/lib/heart-check/executors/base_spec.rb
@@ -1,0 +1,36 @@
+module Heartcheck
+  module Executors
+    describe Base do
+      subject { described_class.new }
+
+      describe '#dispatch' do
+        let(:registered) { 3 }
+
+        let(:checkers) do
+          registered.times.collect do |current|
+            double.tap do |checker|
+              expect(checker).to receive(:check).and_return({ current: 'ok' })
+            end
+          end
+        end
+
+        it 'should register a log entry for each checker' do
+          expect(Logger).to receive(:info).exactly(registered).times
+          subject.dispatch(checkers)
+        end
+
+        it "should have a :time key in the checker response" do
+          subject.dispatch(checkers).each do |current|
+            expect(current).to include(:time)
+          end
+        end
+
+        it "should have a float value (time key)" do
+          subject.dispatch(checkers).each do |current|
+            expect(current[:time]).to be_a(Float)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### New features
- Extract executor to a expecific adapter
- Track execution time and append to the responses individually

#### Change output format to:
```json
[{"version":{"status":"ok"},"time":0.063486},{"cache":{"status":"ok"},"time":2.016598}]
```