### PR TITLE
Adds support for ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - "2.1.5"
   - "2.2.1"
   - "2.2.2"
+  - "2.3.0"
 install: bundle install -j 4 --retry 3
 script:
   - bin/rspec

--- a/heartcheck.gemspec
+++ b/heartcheck.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rack', '~> 1', '>= 1.4.0'
   spec.add_runtime_dependency 'oj'
+  spec.add_runtime_dependency 'net-telnet', '~> 0.1.1'
 
   spec.add_development_dependency 'pry-nav', '~> 0.2.0', '>= 0.2.4'
   spec.add_development_dependency 'rspec', '~> 3.1.0', '>= 3.1.0'


### PR DESCRIPTION
As per [Feature #11083](https://bugs.ruby-lang.org/issues/11083), the `net/telnet` standard library has been gemified. `services/firewall.rb` requires `net/telnet`, so it breaks when running `heartcheck` under Ruby 2.3.0.

This PR adds support for it.