### PR TITLE
Adds /environment route for system info: Ruby, Rails and OS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem install bundler
 install: bundle install -j 4 --retry 3
 script:
   - bin/rspec

--- a/heartcheck.gemspec
+++ b/heartcheck.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rack', '>= 1.4.0', '< 2.1'
   spec.add_runtime_dependency 'multi_json', '~> 1.0'
   spec.add_runtime_dependency 'net-telnet', '~> 0.1.1'
+  spec.add_runtime_dependency 'sys-uname', '~> 1.0', '>= 1.0.3'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'pry-nav', '~> 0.2.4'

--- a/lib/heartcheck/app.rb
+++ b/lib/heartcheck/app.rb
@@ -16,7 +16,8 @@ module Heartcheck
       '/functional' => Controllers::Functional,
       '/dev' => Controllers::Dev,
       '/info' => Controllers::Info,
-      '/health_check' => Controllers::HealthCheck
+      '/health_check' => Controllers::HealthCheck,
+      '/environment' => Controllers::Environment
     }
 
     # Sets up the rack application.

--- a/lib/heartcheck/controllers/environment.rb
+++ b/lib/heartcheck/controllers/environment.rb
@@ -6,9 +6,9 @@ module Heartcheck
       def index
         MultiJson.dump(
           {
-            'system-info' => Sys::Uname.uname,
-            'ruby-version' => RUBY_VERSION,
-            'rails-version' => defined?(Rails) ? Rails::VERSION::STRING : '(none)'
+            :system_info => Sys::Uname.uname.to_h,
+            :ruby_version => RUBY_VERSION,
+            :rails_version => defined?(Rails) ? Rails::VERSION::STRING : '(none)'
           }
         )
       end

--- a/lib/heartcheck/controllers/environment.rb
+++ b/lib/heartcheck/controllers/environment.rb
@@ -6,7 +6,7 @@ module Heartcheck
       def index
         MultiJson.dump(
           {
-            :system_info => Sys::Uname.uname.to_h,
+            :system_info => Hash[Sys::Uname.uname.each_pair.to_a],
             :ruby_version => RUBY_VERSION,
             :rails_version => defined?(Rails) ? Rails::VERSION::STRING : '(none)'
           }

--- a/lib/heartcheck/controllers/environment.rb
+++ b/lib/heartcheck/controllers/environment.rb
@@ -1,0 +1,17 @@
+require 'sys-uname'
+
+module Heartcheck
+  module Controllers
+    class Environment < Base
+      def index
+        MultiJson.dump(
+          {
+            'system-info' => Sys::Uname.uname,
+            'ruby-version' => RUBY_VERSION,
+            'rails-version' => defined?(Rails) ? Rails::VERSION::STRING : '(none)'
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/heartcheck/controllers/environment_spec.rb
+++ b/spec/lib/heartcheck/controllers/environment_spec.rb
@@ -9,7 +9,7 @@ module Heartcheck
           stub_const('RUBY_VERSION', '2.4.0')
         end
 
-        system_info_example = { :example_key => 'example_value' }
+        let(:system_info_example) { Struct.new(:example_key).new('example_value') }
 
         context "given Rails is used" do
           before do
@@ -17,12 +17,13 @@ module Heartcheck
           end
 
           it 'gets info from the right constants and functions' do
-            allow(Sys::Uname).to receive_message_chain(:uname, :each_pair, :to_a).and_return([[:example_key, "example_value"]])
+            allow(Sys::Uname).to receive(:uname).and_return(system_info_example)
             is_expected.to include(
-              :system_info => system_info_example,
+              :system_info => { :example_key => 'example_value' },
               :ruby_version => '2.4.0',
               :rails_version => '5.0.0'
             )
+            expect(Sys::Uname).to have_received(:uname)
           end
 
           let(:system_info) do
@@ -60,12 +61,13 @@ module Heartcheck
 
         context "given Rails is not used" do
           it 'gets the info indicating Rails is not used' do
-            allow(Sys::Uname).to receive_message_chain(:uname, :each_pair, :to_a).and_return([[:example_key, "example_value"]])
+            allow(Sys::Uname).to receive(:uname).and_return(system_info_example)
             is_expected.to include(
-              :system_info => system_info_example,
+              :system_info => { :example_key => 'example_value' },
               :ruby_version => '2.4.0',
               :rails_version => '(none)'
             )
+            expect(Sys::Uname).to have_received(:uname)
           end
         end
       end

--- a/spec/lib/heartcheck/controllers/environment_spec.rb
+++ b/spec/lib/heartcheck/controllers/environment_spec.rb
@@ -17,7 +17,7 @@ module Heartcheck
           end
 
           it 'gets info from the right constants and functions' do
-            allow(Sys::Uname).to receive_message_chain(:uname, :to_h).and_return(system_info_example)
+            allow(Sys::Uname).to receive_message_chain(:uname, :each_pair, :to_a).and_return([[:example_key, "example_value"]])
             is_expected.to include(
               :system_info => system_info_example,
               :ruby_version => '2.4.0',
@@ -60,7 +60,7 @@ module Heartcheck
 
         context "given Rails is not used" do
           it 'gets the info indicating Rails is not used' do
-            allow(Sys::Uname).to receive_message_chain(:uname, :to_h).and_return(system_info_example)
+            allow(Sys::Uname).to receive_message_chain(:uname, :each_pair, :to_a).and_return([[:example_key, "example_value"]])
             is_expected.to include(
               :system_info => system_info_example,
               :ruby_version => '2.4.0',

--- a/spec/lib/heartcheck/controllers/environment_spec.rb
+++ b/spec/lib/heartcheck/controllers/environment_spec.rb
@@ -1,0 +1,74 @@
+module Heartcheck
+  module Controllers
+    describe Environment do
+      subject(:controller) { described_class.new }
+      describe '#index' do
+        subject(:index) { MultiJson.load(controller.index, symbolize_keys: true) }
+
+        before do
+          stub_const('RUBY_VERSION', '2.4.0')
+        end
+
+        system_info_example = { :example_key => 'example_value' }
+
+        context "given Rails is used" do
+          before do
+            stub_const('Rails::VERSION::STRING', '5.0.0')
+          end
+
+          it 'gets info from the right constants and functions' do
+            allow(Sys::Uname).to receive_message_chain(:uname, :to_h).and_return(system_info_example)
+            is_expected.to include(
+              :system_info => system_info_example,
+              :ruby_version => '2.4.0',
+              :rails_version => '5.0.0'
+            )
+          end
+
+          let(:system_info) do
+            MultiJson.load(controller.index, symbolize_keys: true)[:system_info]
+          end
+
+          let(:ruby_version) do
+            MultiJson.load(controller.index, symbolize_keys: true)[:ruby_version]
+          end
+
+          let(:rails_version) do
+            MultiJson.load(controller.index, symbolize_keys: true)[:rails_version]
+          end
+
+          it 'gets the info in the expected format' do
+            expect(system_info).to be_a(Hash)
+            expect(system_info).to include(
+              :sysname,
+              :nodename,
+              :release,
+              :version,
+              :machine,
+              :domainname
+            )
+            expect(system_info[:sysname]).to be_a(String)
+            expect(system_info[:nodename]).to be_a(String)
+            expect(system_info[:release]).to be_a(String)
+            expect(system_info[:version]).to be_a(String)
+            expect(system_info[:machine]).to be_a(String)
+            expect(system_info[:domainname]).to be_a(String)
+            expect(ruby_version).to be_a(String)
+            expect(rails_version).to be_a(String)
+          end
+        end
+
+        context "given Rails is not used" do
+          it 'gets the info indicating Rails is not used' do
+            allow(Sys::Uname).to receive_message_chain(:uname, :to_h).and_return(system_info_example)
+            is_expected.to include(
+              :system_info => system_info_example,
+              :ruby_version => '2.4.0',
+              :rails_version => '(none)'
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This new feature has been created to provide important environment information about the application. This helps the development team to keep the app's documentation updated with:

- System info from "uname" Linux command (kernel-name, nodename, kernel-release, kernel-version, machine and domainname, if available)
- Ruby version
- Rails (if available) version