### PR TITLE
Add doc_url to provide more details about the failure

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 = Heart Check - Changelog
 
+== Version 1.4.0 :: 2017-12-27
+
+ * Adds property `doc_url` to Checks::Base to provide more details about the
+ failure
+
 == Version 1.3.0 :: 2017-09-21
 
  * Adds the `/environment` endpoint

--- a/lib/heartcheck/checks/base.rb
+++ b/lib/heartcheck/checks/base.rb
@@ -30,6 +30,13 @@ module Heartcheck
       # @return [Integer] (default: 0)
       attr_accessor :timeout
 
+      # An url to provide more info about the check.
+      #   It is important to provide details about the failure, for example:
+      #   - what is the impact
+      #   - how to fix it
+      #   - how to reproduce the failure
+      # @return [String] (default: nil)
+      attr_accessor :doc_url
 
       # Create a new instance and set the default values.
       #
@@ -188,7 +195,11 @@ module Heartcheck
       # @return [Hash]
       def format_error
         lambda do |error|
-          error.is_a?(Hash) ? error : { type: 'error', message: error }
+          if error.is_a?(Hash)
+            error
+          else
+            { type: 'error', message: error, doc_url: doc_url }
+          end
         end
       end
     end

--- a/lib/heartcheck/generators/templates/config.rb
+++ b/lib/heartcheck/generators/templates/config.rb
@@ -14,6 +14,8 @@ Heartcheck.setup do |monitor|
   # For each check you can set the folling options
   #        name: String  => root name to show in report page (default: class.name)
   #  functional: Boolean => When is false your check is essential to your application (default: false)
+  #     doc_url: String  => To provide more details about the failure (optional)
+  # (default: nil)
   #    on_error: Block   => to customize the errors (default: nil)
   # to_validate: Block   => to validate the sevices (default: nil)
   #
@@ -23,6 +25,7 @@ Heartcheck.setup do |monitor|
   #   c.name       = "filesystem"
   #   c.functional = true
   #   c.add_service(name: "my_file", path: "/var/www/my_project/my_file")
+  #   c.doc_url    = 'http://docs.com/monitoring#check-filesystem'
   #
   #   c.on_error do |sevices|
   #     errors << "Custom error message for #{service[:name]}"

--- a/spec/lib/heartcheck/checks/base_spec.rb
+++ b/spec/lib/heartcheck/checks/base_spec.rb
@@ -133,12 +133,49 @@ describe Heartcheck::Checks::Base do
       end
 
       it 'returns the errors' do
-        expect(subject.check).to eq('base' => { 'status' => 'error', 'message' => [{ type: 'error', message: 'reaching' }] })
+        expect(subject.check).to eq(
+          'base' => {
+            'status' => 'error',
+            'message' => [{ type: 'error', message: 'reaching', doc_url: nil }]
+          }
+        )
       end
 
       it 'should not accumulate errors' do
         subject.check
-        expect(subject.check).to eq('base' => { 'status' => 'error', 'message' => [{ type: 'error', message: 'reaching' }] })
+        expect(subject.check).to eq(
+          'base' => {
+            'status' => 'error',
+            'message' => [{ type: 'error', message: 'reaching', doc_url: nil }]
+          }
+        )
+      end
+
+      it 'shows the doc_url if present' do
+        # setup
+        doc_url = 'http://lala.com/docs/monitoring'
+        check_item = described_class.new
+        check_item.to_validate do |_services, errors|
+          errors << 'reaching'
+        end
+        check_item.doc_url = doc_url
+
+        # exercise
+        result = check_item.check
+
+        # verify
+        expect(result).to eq(
+          'base' => {
+            'status' => 'error',
+            'message' => [
+              {
+                type: 'error',
+                message: 'reaching',
+                doc_url: doc_url
+              }
+            ]
+          }
+        )
       end
     end
   end


### PR DESCRIPTION
## Motivation

When the path `/monitoring` fails, the ops guys normally don't know how to proceed because they don't know the internals of the code.

## Solution

Add the property `doc_url` to the failure hash to provide more details about it, for example:
- what is the impact
- how to fix it
- how to reproduce the failure

Example:

```json
[
  {
	"storage": {
		"status": "error",
		"message": [{
			"type": "error",
			"message": "The storage is not currently accepting connections",
			"doc_url": "http://docs-lala.com/monitoring-errors#storage"
		}]
	},
	"time": 169.533772
  }
]
```