### PR TITLE
Add inspect endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Then edit the generated file by adding your checks on it and restart your
 server. Now you should be able to make a HTTP request for `/monitoring` and
 get a JSON response that contains the status for each monitored service.
 
+The following environment variables are needed by heartcheck:
+
+    HEARTCHECK_APP_NAME=MyApplicationName
+
+
 ### Using built-in checks
 
 #### Firewall check
@@ -88,6 +93,13 @@ Returns a simple `ok` if the app is running. It does not execute any configured
 checks:
 
     /monitoring/health_check
+
+
+#### General info and dependencies
+
+Returns general application info and a list of dependencies' URIs, but executes no checking:
+
+    /monitoring/inspect
 
 ## Plugins
 

--- a/lib/heartcheck/app.rb
+++ b/lib/heartcheck/app.rb
@@ -16,6 +16,7 @@ module Heartcheck
       '/functional' => Controllers::Functional,
       '/dev' => Controllers::Dev,
       '/info' => Controllers::Info,
+      '/inspect' => Controllers::Inspect,
       '/health_check' => Controllers::HealthCheck,
       '/environment' => Controllers::Environment
     }

--- a/lib/heartcheck/checks/base.rb
+++ b/lib/heartcheck/checks/base.rb
@@ -133,6 +133,13 @@ module Heartcheck
         "#<#{self.class.name} name: #{name}, functional: #{functional?}, dev: #{dev?}>"
       end
 
+      # Returns a structure comprised of host, port and
+      # schema (protocol) for the check
+      #
+      # @return [Hash]
+      def uri_info
+        { error: "#{self.class.name} #url_info not implemented." }
+      end
 
       def informations
         info

--- a/lib/heartcheck/checks/firewall.rb
+++ b/lib/heartcheck/checks/firewall.rb
@@ -16,6 +16,16 @@ module Heartcheck
         end
       end
 
+      def uri_info
+        services.map do |s|
+          {
+            host: s.uri.host,
+            port: s.uri.port,
+            scheme: s.uri.scheme
+          }
+        end
+      end
+
       private
 
       def custom_error(service)

--- a/lib/heartcheck/controllers/inspect.rb
+++ b/lib/heartcheck/controllers/inspect.rb
@@ -10,7 +10,7 @@ module Heartcheck
         checks = Heartcheck.checks
         results[:dependencies] += checks.reduce([]) do |acc, elem|
           acc << elem.uri_info
-        end.flatten
+        end.flatten.uniq
 
         MultiJson.dump(results)
       end

--- a/lib/heartcheck/controllers/inspect.rb
+++ b/lib/heartcheck/controllers/inspect.rb
@@ -4,7 +4,6 @@ module Heartcheck
       def index
         results = {
           application_name: application_name,
-          environment: environment,
           dependencies: []
         }
 
@@ -20,10 +19,6 @@ module Heartcheck
 
       def application_name
         ENV.fetch('HEARTCHECK_APP_NAME')
-      end
-
-      def environment
-        ENV.fetch('RAILS_ENV')
       end
     end
   end

--- a/lib/heartcheck/controllers/inspect.rb
+++ b/lib/heartcheck/controllers/inspect.rb
@@ -1,0 +1,20 @@
+module Heartcheck
+  module Controllers
+    class Inspect < Base
+      def index
+        results = {
+          application_name: Rails.application.class.name,
+          environment: ENV['RAILS_ENV'],
+          dependencies: []
+        }
+
+        checks = Heartcheck.checks
+        results[:dependencies] += checks.reduce([]) do |acc, elem|
+          acc << elem.uri_info
+        end.flatten
+
+        MultiJson.dump(results)
+      end
+    end
+  end
+end

--- a/lib/heartcheck/controllers/inspect.rb
+++ b/lib/heartcheck/controllers/inspect.rb
@@ -3,8 +3,8 @@ module Heartcheck
     class Inspect < Base
       def index
         results = {
-          application_name: Rails.application.class.name,
-          environment: ENV['RAILS_ENV'],
+          application_name: application_name,
+          environment: environment,
           dependencies: []
         }
 
@@ -14,6 +14,16 @@ module Heartcheck
         end.flatten
 
         MultiJson.dump(results)
+      end
+
+      private
+
+      def application_name
+        ENV.fetch('HEARTCHECK_APP_NAME')
+      end
+
+      def environment
+        ENV.fetch('RAILS_ENV')
       end
     end
   end

--- a/spec/lib/heartcheck/checks/base_spec.rb
+++ b/spec/lib/heartcheck/checks/base_spec.rb
@@ -202,4 +202,15 @@ describe Heartcheck::Checks::Base do
       end
     end
   end
+
+  describe '#uri_info' do
+    context 'for the base class' do
+      it 'returns a hash with an error message' do
+        expect(subject.uri_info).to include(:error)
+        expect(subject.uri_info).not_to include(:host)
+        expect(subject.uri_info).not_to include(:port)
+        expect(subject.uri_info).not_to include(:schema)
+      end
+    end
+  end
 end

--- a/spec/lib/heartcheck/checks/firewall_spec.rb
+++ b/spec/lib/heartcheck/checks/firewall_spec.rb
@@ -13,6 +13,24 @@ describe Heartcheck::Checks::Firewall do
     end
   end
 
+  describe '#uri_info' do
+    context 'when multiple services are being checked' do
+      before do
+        subject.add_service(url: 'http://url1.com')
+        subject.add_service(url: 'https://url2.com')
+        subject.add_service(url: 'http://url3.com')
+      end
+
+      it 'returs a list os URI hashes' do
+        result = subject.uri_info
+
+        expect(result).to eq([{host: 'url1.com', port: 80, scheme: 'http'},
+                              {host: 'url2.com', port: 443, scheme: 'https'},
+                              {host: 'url3.com', port: 80, scheme: 'http'}])
+      end
+    end
+  end
+
   describe '#validate' do
     subject { instance_default }
 


### PR DESCRIPTION
An inspection endpoint is being implemented in a non-intrusive
way to support future functionality planned by IaaS team, such
as dependencies graph building and advanced visual monitoring.

All check plug-ins must implement their own version of #uri_info
to be shown in the dependencies collection. Such implementations
will be provided soon in future PRs.

Signed-off-by: Luiz Carlos Cavalcanti <cavalcanti.luiz@gmail.com>