### PR TITLE
Fixing firewall inspect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-before_install: gem install bundler
+before_install: gem install bundler -v 1.17.3
 install: bundle install -j 4 --retry 3
 script:
   - bin/rspec

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 = Heart Check - Changelog
 
+== Version 1.5.1 :: 2019-05-16
+
+ * Fixing '/monitoring/inspect' endpoint on rendering items of firewall
+
 == Version 1.5.0 :: 2018-11-29
 
  * Adds the '/monitoring/inspect' endpoint to get general info and dependencies

--- a/lib/heartcheck/checks/firewall.rb
+++ b/lib/heartcheck/checks/firewall.rb
@@ -8,7 +8,7 @@ module Heartcheck
       def validate
         services.each do |service|
           begin
-            Net::Telnet.new(service.params)
+            Net::Telnet.new(service.params).close
           rescue Errno::ECONNREFUSED; nil
           rescue
             append_error(service)
@@ -33,7 +33,7 @@ module Heartcheck
 
         if service.proxy
           proxy_uri = URI(service.proxy)
-          error_message << " via proxy: #{proxy_uri.host}:#{proxy_uri.port}"
+          error_message << " using proxy: #{proxy_uri.host}:#{proxy_uri.port}"
         end
 
         @errors << error_message

--- a/lib/heartcheck/checks/firewall.rb
+++ b/lib/heartcheck/checks/firewall.rb
@@ -17,11 +17,11 @@ module Heartcheck
       end
 
       def uri_info
-        services.map do |s|
+        services.map do |service|
           {
-            host: s.uri.host,
-            port: s.uri.port,
-            scheme: s.uri.scheme
+            host: service.host,
+            port: service.port,
+            scheme: service.uri.scheme || ''
           }
         end
       end

--- a/lib/heartcheck/version.rb
+++ b/lib/heartcheck/version.rb
@@ -1,3 +1,3 @@
 module Heartcheck
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'.freeze
 end

--- a/spec/lib/heartcheck/checks/firewall_spec.rb
+++ b/spec/lib/heartcheck/checks/firewall_spec.rb
@@ -19,6 +19,7 @@ describe Heartcheck::Checks::Firewall do
         subject.add_service(url: 'http://url1.com')
         subject.add_service(url: 'https://url2.com')
         subject.add_service(url: 'http://url3.com')
+        subject.add_service(host: 'url4.com', port: 80)
       end
 
       it 'returs a list os URI hashes' do
@@ -26,7 +27,8 @@ describe Heartcheck::Checks::Firewall do
 
         expect(result).to eq([{host: 'url1.com', port: 80, scheme: 'http'},
                               {host: 'url2.com', port: 443, scheme: 'https'},
-                              {host: 'url3.com', port: 80, scheme: 'http'}])
+                              {host: 'url3.com', port: 80, scheme: 'http'},
+                              {host: 'url4.com', port: 80, scheme: ''}])
       end
     end
   end


### PR DESCRIPTION
Using a item of firewall with host/port and call `/monitoring/inspect`, renders a json with nil in attributes:

```json
{
  "application_name": "MyApi",
  "dependencies": [
    {
      "host": null,
      "port": null,
      "scheme": null
    }
  ]
}

```
after fix:
```json
{
  "application_name": "MyApi",
  "dependencies": [
    {
      "host": "url1.com",
      "port": 80,
      "scheme": ""
    }
  ]
}
```


