### PR TITLE
Travis get latest versions of Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,15 @@ script:
   - bin/rspec
 matrix:
   include:
-    - rvm: "1.9.3"
+    - rvm: 1.9
       gemfile: Gemfile-old-ruby
-    - rvm: "2.0.0"
+    - rvm: 2.0
       gemfile: Gemfile-old-ruby
-    - rvm: "2.1.0"
+    - rvm: 2.1
       gemfile: Gemfile-old-ruby
-    - rvm: "2.1.5"
+    - rvm: 2.2
       gemfile: Gemfile-old-ruby
-    - rvm: "2.2.1"
-      gemfile: Gemfile-old-ruby
-    - rvm: "2.2.2"
-    - rvm: "2.3.0"
-    - rvm: "2.3.3"
-    - rvm: "2.4.1"
-    - rvm: "2.5.7"
-    - rvm: "2.6.5"
+    - rvm: 2.3
+    - rvm: 2.4
+    - rvm: 2.5
+    - rvm: 2.6


### PR DESCRIPTION
# Motivation
As Ruby release some patch version, we need to update travis to build against new versions.

# Proposed Solution
Set to minor versions, and travis in the background will do a `rvm use 2.3` and get the latest version of Ruby 2.3 and so on..

# Observations
Removed duplicated Ruby versions.

 Happy Hacktoberfest! @rhruiz @fabioperrella 