### PR TITLE
Add RubyCritic gem in the stack.

### DIFF
--- a/.rubycritic.yml
+++ b/.rubycritic.yml
@@ -1,0 +1,13 @@
+mode_ci:
+  enabled: true # default is false
+  branch: 'production' # default is master
+branch: 'production' # default is master
+path:  # Set path where report will be saved (tmp/rubycritic by default)
+threshold_score: 10 # default is 0
+deduplicate_symlinks: true # default is false
+suppress_ratings: true # default is false
+no_browser: true # default is false
+formats: # Available values are: html, json, console, lint. Default value is html.
+  - console
+minimum_score: 80 # default is 0
+paths: # Files to analyse.

--- a/heartcheck.gemspec
+++ b/heartcheck.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.5.0'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubycritic'
   spec.add_development_dependency 'thor', '~> 0.19.1'
   spec.add_development_dependency 'yard', '~> 0.9.5'
 end


### PR DESCRIPTION
This PR adds RubyCritic to ensure the code quality is upto the threshold which means of good quality ofcourse.

I have added a config file where the checks can be configured accordingly later. The initial score is 80.32 which is set as current threshold.

All you have to do is run `rubycritic` and it will run the entire directory.

<img width="1649" alt="image" src="https://user-images.githubusercontent.com/4223130/135660368-a68a6770-beb8-4b76-9eec-c4f32193ba69.png">

![image (137)](https://user-images.githubusercontent.com/4223130/135660426-a39885e6-c9c8-4ae3-b932-9d60539bb486.png)


Note: If you spot any issue around folder not being found, it will create a tmp folder inside the app. You might have to create a folder named `compare` and move the `build_number.txt` inside the folder(compare) and should be good.
