### PR TITLE
Fixes broken tests in CI due ruby version and minor improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          bundler: 1.17.3
 
       - name: Run tests
         run: bundle exec rspec
+
+      - name: Run linter
+        run: bundle exec rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Ruby and Bundler
+      - name: Set up Ruby, bundler and dependencies
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,25 @@
-name: ci
+name: CI
 
-on:
-  push:
-    branches:
-      - "*"
-  pull_request:
-    branches:
-      - "*"
+on: [push, pull_request]
 
 jobs:
-  testgi:
-    runs-on: ubuntu-latest
+  test:
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ["2.6", "2.7", "3.0"]
+        os: [ubuntu-latest]
+        ruby: ["2.6", "2.7", "3.0"]
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
+      - uses: actions/checkout@v2
 
-    - name: Run tests
-      run: |
-          bundle install --jobs 4 --retry 3
-          bundle exec rspec
+      - name: Set up Ruby and Bundler
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+          bundler: 1.17.3
+
+      - name: Run tests
+        run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.gems/
 *.gem
 *.rbc
 .bundle

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,5 @@
 = Heart Check - Changelog
 
-== Version 2.4.0 :: 2021-10-01
- * Add docker to facilitate development
-
 == Version 2.3.1 :: 2021-06-14
  * Move and rename GitHub template files to correct folder
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ declare service checks and an URI that returns the status for each service.
 With this gem you can monitor if your app has access to the database, a cache
 service, an API, etc.
 
-[![Build Status](https://travis-ci.org/locaweb/heartcheck.svg)](https://travis-ci.org/locaweb/heartcheck)
+[![Build Status](https://github.com/locaweb/heartcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/locaweb/heartcheck/actions/workflows/ci.yml)
 [![Code Climate](https://codeclimate.com/github/locaweb/heartcheck/badges/gpa.svg)](https://codeclimate.com/github/locaweb/heartcheck)
 [![Ebert](https://ebertapp.io/github/locaweb/heartcheck.svg)](https://ebertapp.io/github/locaweb/heartcheck)
 

--- a/lib/heartcheck/checks/firewall.rb
+++ b/lib/heartcheck/checks/firewall.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 module Heartcheck
   module Checks


### PR DESCRIPTION
# Description

Fix tests that are broken in CI due ruby version by removing freeze from literal string.
Also, added linter step to CI, ignored `.gems/` folder, updated build badge to point to github actions and removed duplicated bundle install.
 
## Type of branch

Hotfix
 
## Type of change
 
- [x] Bug fix (non-breaking change which fixes an issue)
 
# How Has This Been Tested?
 
Running in forked repo CI.
 
# Checklist:
 
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
