### PR TITLE
Remove unecessary line break after processing checks

### DIFF
--- a/lib/heartcheck/app.rb
+++ b/lib/heartcheck/app.rb
@@ -64,7 +64,7 @@ module Heartcheck
       Logger.info "Start [#{controller}] from #{req.ip} at #{Time.now}"
 
       controller.new.index.tap do |_|
-        Logger.info "End [#{controller}]\n"
+        Logger.info "End [#{controller}]"
       end
     end
   end

--- a/lib/heartcheck/caching_app/cache.rb
+++ b/lib/heartcheck/caching_app/cache.rb
@@ -40,7 +40,7 @@ module Heartcheck
         proc do
           Logger.info("Start [#{controller}] for caching at #{Time.now}")
           @results[controller] = controller.new.index
-          Logger.info("End [#{controller}]\n")
+          Logger.info("End [#{controller}]")
         end
       end
 


### PR DESCRIPTION
# Description
 
It avoids creating an empty log line at the end of the call and creating an empty register inside the log collector (datadog, elk, etc.)

![image](https://github.com/locaweb/heartcheck/assets/18632496/076f9097-c937-4b3e-9d46-1028ec8326f6)

## Type of branch
Please delete options that are not relevant.
 
Bug # (issue)
 
## Type of change
 
Please delete options that are not relevant.
 
- [x] Bug fix (non-breaking change which fixes an issue)
 
# How Has This Been Tested?
 
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
 
- By just running the heartcheck
 
# Checklist:
 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
