### PR TITLE
Allow Rack 3.0

### DIFF
--- a/heartcheck.gemspec
+++ b/heartcheck.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'multi_json', '~> 1.0'
   spec.add_runtime_dependency 'net-telnet', '~> 0.1.1'
-  spec.add_runtime_dependency 'rack', '~> 2.2'
+  spec.add_runtime_dependency 'rack', '> 2.2', '< 4'
   spec.add_runtime_dependency 'sys-uname', '~> 1.0', '>= 1.0.3'
 
   spec.add_development_dependency 'concurrent-ruby', '~> 1.0.2'


### PR DESCRIPTION
Avoid this when using heartcheck with a more recent rails:

```
Installing rack 2.2.8 (was 3.0.8)
Using standard 1.33.0
Installing ffi 1.16.3 with native extensions
Fetching rack-session 1.0.2 (was 2.0.0)
Using rack-test 2.1.0
Fetching rackup 1.0.0 (was 2.1.0)
Installing rack-session 1.0.2 (was 2.0.0)
Installing rackup 1.0.0 (was 2.1.0)
```
